### PR TITLE
Fix issue on non US keyboards.

### DIFF
--- a/webmux/static/js/views/term.js
+++ b/webmux/static/js/views/term.js
@@ -2257,7 +2257,8 @@ define(["underscore", "backbone"], function(_, Backbone) {
                     break;
                 default:
                     // a-z and space
-                    if (ev.ctrlKey) {
+                    if (ev.altKey && ev.ctrlKey) {
+                    } else if (ev.ctrlKey) {
                         if (ev.keyCode >= 65 && ev.keyCode <= 90) {
                             // Ctrl-A
                             if (this.screenKeys) {


### PR DESCRIPTION
On some keyboard layouts as French layouts and reportedly Italian and
german layouts, some keys were not detected in conjunction with the AltGr
modification key. This commit fix this issue, providing a workaround
for french keyboards to produce the '#', '{', '[' and '|' characters.
